### PR TITLE
Initial Docker CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,3 +19,4 @@ jobs:
       uses: docker/build-push-action@v5
       with:
         push: false
+        tags: timveil/cockroachdb-remote-client:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,5 +26,5 @@ jobs:
     - name: Build with Docker
       uses: docker/build-push-action@v5
       with:
-        push: false
+        push: ${{ github.ref == 'refs/heads/master' }}
         tags: timveil/cockroachdb-remote-client:latest,timveil/cockroachdb-remote-client:${{ steps.tag.outputs.short_sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,8 +15,16 @@ jobs:
     - name: Checkout Project
       uses: actions/checkout@v2
 
+    - name: Determine SHA tag for Docker image
+      id: tag
+      run: |
+        SHA=${{ github.event.after }}
+        SHORT_SHA=${SHA::8}
+        echo "short_sha=${SHORT_SHA}" | tee "$GITHUB_OUTPUT"
+
+
     - name: Build with Docker
       uses: docker/build-push-action@v5
       with:
         push: false
-        tags: timveil/cockroachdb-remote-client:latest
+        tags: timveil/cockroachdb-remote-client:latest,timveil/cockroachdb-remote-client:${{ steps.tag.outputs.short_sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,9 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,3 +39,4 @@ jobs:
       with:
         push: ${{ github.ref == 'refs/heads/master' }}
         tags: ${{ secrets.DOCKERHUB_REPO }}:latest,${{ secrets.DOCKERHUB_REPO }}:${{ steps.tag.outputs.short_sha }}
+        platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,9 @@ jobs:
         SHORT_SHA=${SHA::8}
         echo "short_sha=${SHORT_SHA}" | tee "$GITHUB_OUTPUT"
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
     - name: Login to Docker Hub
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,21 @@
+name: Docker CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Project
+      uses: actions/checkout@v2
+
+    - name: Build with Docker
+      uses: docker/build-push-action@v5
+      with:
+        push: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,9 +22,14 @@ jobs:
         SHORT_SHA=${SHA::8}
         echo "short_sha=${SHORT_SHA}" | tee "$GITHUB_OUTPUT"
 
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build with Docker
       uses: docker/build-push-action@v5
       with:
         push: ${{ github.ref == 'refs/heads/master' }}
-        tags: timveil/cockroachdb-remote-client:latest,timveil/cockroachdb-remote-client:${{ steps.tag.outputs.short_sha }}
+        tags: ${{ secrets.DOCKERHUB_REPO }}:latest,${{ secrets.DOCKERHUB_REPO }}:${{ steps.tag.outputs.short_sha }}


### PR DESCRIPTION
Recently, an image was pushed to `timveil/cockroachdb-remote-client:latest` that was build only for `arm64` instead of the previous `amd64`.

This PR adds CI to build for multiple platforms, as well as tagging with the 8 character short-SHA of the build commit, matching Github's short-SHA format.

Required Github repository secrets:
- `DOCKERHUB_REPO`: where to push the image, i.e. `timveil/cockroachdb-remote-client`
- `DOCKERHUB_USERNAME`: Docker Hub auth user
- `DOCKERHUB_TOKEN`: Docker Hub access token

Docker Hub repo of fork: https://hub.docker.com/r/cjfinnell/cockroachdb-remote-client/tags 